### PR TITLE
feat: add bottom dock with info chat settings

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,19 +1,14 @@
 // No React import needed for JSX in React 18+
-import { HUD } from '@/ui/HUD';
 import { NameTag } from '@/ui/NameTag';
 import { PortalUI } from '@/ui/PortalUI';
+import { Dock } from '@/ui/Dock';
 
 export function App(): JSX.Element {
   return (
     <>
-      {/* HUD: koordinatlar + yön */}
-      <HUD />
-      
-      {/* Avatar etiketi */}
       <NameTag name="macaris64" />
-      
-      {/* Portal UI and related overlays */}
       <PortalUI />
+      <Dock />
     </>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,7 +11,7 @@ import { AvatarFactory, updateAvatar } from '@/world/entities';
 import { createWorldFX } from '@/world/worldfx';
 import { createPortalSystem, createPresetController } from '@/systems/portal';
 import { createMarquee } from '@/systems/marquee';
-import * as utils from '@/core/utils';
+import { runtime } from '@/state/runtime';
 import '@/styles/global.css';
 
 // Bootstrap React
@@ -30,7 +30,6 @@ setTimeout(() => {
 
 function initializeThreeWorld() {
   // Get DOM elements that React has rendered
-  const hud = document.getElementById('hud');
   const nameTag = document.getElementById('nameTag');
   const portalUI = document.getElementById('portalUI');
   const portalList = document.getElementById('portalList');
@@ -39,7 +38,7 @@ function initializeThreeWorld() {
   const portalHint = document.getElementById('portalHint');
   const fade = document.getElementById('fade');
 
-  if (!hud || !nameTag || !portalUI || !portalList || !btnCancel || !btnTeleport || !portalHint || !fade) {
+  if (!nameTag || !portalUI || !portalList || !btnCancel || !btnTeleport || !portalHint || !fade) {
     throw new Error('Required DOM elements not found');
   }
 
@@ -172,26 +171,25 @@ function initializeThreeWorld() {
   function animate() {
     requestAnimationFrame(animate);
     const dt = Math.min(0.033, clock.getDelta());
-    updateAvatar(dt, avatar, keys, camera, controls, { 
-      insideStageXZ, 
-      groundYAt, 
-      planeSize, 
-      stageTopY, 
-      roomBlock, 
-      buildingBlock, 
-      boardBlock 
+    updateAvatar(dt, avatar, keys, camera, controls, {
+      insideStageXZ,
+      groundYAt,
+      planeSize,
+      stageTopY,
+      roomBlock,
+      buildingBlock,
+      boardBlock
     });
+    runtime.avatar.x = avatar.position.x;
+    runtime.avatar.y = avatar.position.y;
+    runtime.avatar.z = avatar.position.z;
+    runtime.avatar.rotY = avatar.rotation.y;
     worldfx.update();
     updatePortalProximity();
     marquee.update(dt);
     adaptiveQuality();
     controls.update();
     renderer.render(scene, camera);
-
-    const heading = ((utils.deg(avatar.rotation.y) % 360) + 360) % 360;
-    if (hud) {
-      hud.textContent = `x: ${utils.fmt(avatar.position.x)}\ny: ${utils.fmt(avatar.position.y)}\nz: ${utils.fmt(avatar.position.z)}\nrotY: ${heading.toFixed(1)}°`;
-    }
     updateNameTag();
   }
   animate();

--- a/src/state/runtime.ts
+++ b/src/state/runtime.ts
@@ -1,0 +1,3 @@
+export const runtime = {
+  avatar: { x: 0, y: 0, z: 0, rotY: 0 },
+};

--- a/src/ui/Dock.tsx
+++ b/src/ui/Dock.tsx
@@ -1,10 +1,57 @@
-// No React import needed for JSX in React 18+
+import { useState, useEffect, useCallback } from 'react';
+import { InfoTab } from '@/ui/tabs/InfoTab';
+import { ChatTab } from '@/ui/tabs/ChatTab';
+import { SettingsTab } from '@/ui/tabs/SettingsTab';
+import './dock.css';
 
-export interface DockProps {
-  // Placeholder for future dock functionality
+type Tab = 'info' | 'chat' | 'settings';
+
+export function Dock(): JSX.Element {
+  const [active, setActive] = useState<Tab>('info');
+
+  const handleKey = useCallback((e: KeyboardEvent) => {
+    if (!e.altKey) return;
+    if (e.key === '1') setActive('info');
+    if (e.key === '2') setActive('chat');
+    if (e.key === '3') setActive('settings');
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [handleKey]);
+
+  return (
+    <div className="dock" id="dock">
+      <div className="tabs">
+        <button
+          className={active === 'info' ? 'tab active' : 'tab'}
+          onClick={() => setActive('info')}
+          aria-label="Info"
+        >
+          ℹ️
+        </button>
+        <button
+          className={active === 'chat' ? 'tab active' : 'tab'}
+          onClick={() => setActive('chat')}
+          aria-label="Chat"
+        >
+          💬
+        </button>
+        <button
+          className={active === 'settings' ? 'tab active' : 'tab'}
+          onClick={() => setActive('settings')}
+          aria-label="Settings"
+        >
+          ⚙️
+        </button>
+      </div>
+      <div className="content">
+        {active === 'info' && <InfoTab />}
+        {active === 'chat' && <ChatTab />}
+        {active === 'settings' && <SettingsTab />}
+      </div>
+    </div>
+  );
 }
 
-export function Dock(_props: DockProps): JSX.Element | null {
-  // Placeholder component - not rendered in the current implementation
-  return null;
-}

--- a/src/ui/dock.css
+++ b/src/ui/dock.css
@@ -1,0 +1,51 @@
+.dock {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  width: min(340px, 90vw);
+  height: min(260px, 50vh);
+  display: flex;
+  flex-direction: column;
+  background: rgba(10,12,18,.85);
+  border: 1px solid rgba(255,255,255,.12);
+  border-radius: 12px;
+  box-shadow: 0 20px 40px rgba(0,0,0,.5);
+  color: #E8F0FF;
+  font: 14px/1.45 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  z-index: 11;
+}
+
+.dock .tabs {
+  display: flex;
+  height: 44px;
+  border-bottom: 1px solid rgba(255,255,255,.08);
+}
+
+.dock .tab {
+  flex: 1;
+  background: none;
+  border: none;
+  color: #d0dcff;
+  cursor: pointer;
+  font-size: 18px;
+}
+
+.dock .tab.active {
+  background: rgba(130,180,255,.18);
+}
+
+.dock .content {
+  flex: 1;
+  padding: 12px 14px;
+  overflow: auto;
+}
+
+.dock h2 {
+  margin: 0 0 8px 0;
+  font-size: 16px;
+}
+
+.dock label {
+  display: block;
+  margin-bottom: 6px;
+}

--- a/src/ui/tabs/ChatTab.tsx
+++ b/src/ui/tabs/ChatTab.tsx
@@ -1,0 +1,9 @@
+export function ChatTab(): JSX.Element {
+  return (
+    <div className="chat-tab">
+      <h2>Chat</h2>
+      <div className="messages"></div>
+      <p>coming soon</p>
+    </div>
+  );
+}

--- a/src/ui/tabs/InfoTab.tsx
+++ b/src/ui/tabs/InfoTab.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+import { runtime } from '@/state/runtime';
+import * as utils from '@/core/utils';
+
+interface AvatarState {
+  x: number;
+  y: number;
+  z: number;
+  rotY: number;
+}
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+function fmtTime(ms: number): string {
+  const total = Math.floor(ms / 1000);
+  const h = pad(Math.floor(total / 3600));
+  const m = pad(Math.floor((total % 3600) / 60));
+  const s = pad(total % 60);
+  return `${h}:${m}:${s}`;
+}
+
+export function InfoTab(): JSX.Element {
+  const [avatar, setAvatar] = useState<AvatarState>({ x: 0, y: 0, z: 0, rotY: 0 });
+  const [clock, setClock] = useState(new Date());
+  const [remaining, setRemaining] = useState(20 * 60 * 1000);
+  const [finished, setFinished] = useState(false);
+
+  useEffect(() => {
+    const sessionEnd = Date.now() + 20 * 60 * 1000;
+    const posTimer = setInterval(() => {
+      setAvatar({
+        x: runtime.avatar.x,
+        y: runtime.avatar.y,
+        z: runtime.avatar.z,
+        rotY: runtime.avatar.rotY,
+      });
+    }, 100);
+    const timeTimer = setInterval(() => {
+      const now = new Date();
+      setClock(now);
+      const rem = Math.max(0, sessionEnd - now.getTime());
+      setRemaining(rem);
+      setFinished(rem === 0);
+    }, 1000);
+    return () => {
+      clearInterval(posTimer);
+      clearInterval(timeTimer);
+    };
+  }, []);
+
+  const heading = ((utils.deg(avatar.rotY) % 360) + 360) % 360;
+  const clockStr = `${pad(clock.getHours())}:${pad(clock.getMinutes())}:${pad(clock.getSeconds())}`;
+
+  return (
+    <div className="info-tab">
+      <div>Session name: Garden Session</div>
+      <div>
+        Position: {utils.fmt(avatar.x)} / {utils.fmt(avatar.y)} / {utils.fmt(avatar.z)}
+      </div>
+      <div>Rot Y: {heading.toFixed(1)}</div>
+      <div>System time: {clockStr}</div>
+      <div>Online users: 1</div>
+      <div>
+        Time left: {fmtTime(remaining)}{finished ? ' • Session finished' : ''}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/tabs/SettingsTab.tsx
+++ b/src/ui/tabs/SettingsTab.tsx
@@ -1,0 +1,10 @@
+export function SettingsTab(): JSX.Element {
+  return (
+    <div className="settings-tab">
+      <h2>Settings</h2>
+      <label><input type="checkbox" /> Enable notifications</label>
+      <label><input type="checkbox" /> Dark mode</label>
+      <label><input type="checkbox" /> Experimental feature</label>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add runtime state for avatar tracking and expose to UI
- replace HUD with bottom-right Dock containing Info, Chat, and Settings tabs
- show session info, countdown, and placeholders for chat/settings

## Testing
- `npm test` (fails: Missing script "test")
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689cdf1a2b308324a70a34bc732d6053