### PR TITLE
feat: add admin bot management

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,6 +13,8 @@ import { createPortalSystem, createPresetController } from '@/systems/portal';
 import { createMarquee } from '@/systems/marquee';
 import { createTeleprompterRig } from '@/scene/teleprompter/createTeleprompterRig';
 import { runtime } from '@/state/runtime';
+import { BotManager } from '@/world/bots/BotManager';
+import { botControls } from '@/state/bots';
 import '@/styles/global.css';
 
 // Bootstrap React
@@ -100,6 +102,13 @@ function initializeThreeWorld() {
 
   // Instructor teleprompter + timer display
   const teleprompter = createTeleprompterRig(THREE, scene, { stage, stageTopY });
+
+  // Bot avatars
+  const botManager = new BotManager();
+  botManager.init({ scene, glassRoomRef: { room: glassRoom, w: STAGE_W, d: STAGE_D }, avatarFactory });
+  botControls.setEnabled = (v: boolean) => botManager.setEnabled(v);
+  botControls.setCount = (n: number) => botManager.setCount(n);
+  window.addEventListener('beforeunload', () => botManager.dispose());
 
   // UI / Teleport akışı — tüm ID'ler aynı spawn (varsayılan)
   function spawnDefault() {
@@ -192,6 +201,7 @@ function initializeThreeWorld() {
     updatePortalProximity();
     marquee.update(dt);
     teleprompter.update(dt);
+    botManager.update(dt);
     adaptiveQuality();
     controls.update();
     renderer.render(scene, camera);

--- a/src/state/bots.ts
+++ b/src/state/bots.ts
@@ -1,0 +1,4 @@
+export const botControls = {
+  setEnabled: (_enabled: boolean): void => {},
+  setCount: (_n: number): void => {},
+};

--- a/src/ui/Dock.tsx
+++ b/src/ui/Dock.tsx
@@ -2,9 +2,10 @@ import { useState, useEffect, useCallback } from 'react';
 import { InfoTab } from '@/ui/tabs/InfoTab';
 import { ChatTab } from '@/ui/tabs/ChatTab';
 import { SettingsTab } from '@/ui/tabs/SettingsTab';
+import { AdminTab } from '@/ui/tabs/AdminTab';
 import './dock.css';
 
-type Tab = 'info' | 'chat' | 'settings';
+type Tab = 'info' | 'chat' | 'settings' | 'admin';
 
 export function Dock(): JSX.Element {
   const [active, setActive] = useState<Tab>('info');
@@ -14,6 +15,7 @@ export function Dock(): JSX.Element {
     if (e.key === '1') setActive('info');
     if (e.key === '2') setActive('chat');
     if (e.key === '3') setActive('settings');
+    if (e.key === '4') setActive('admin');
   }, []);
 
   useEffect(() => {
@@ -45,11 +47,19 @@ export function Dock(): JSX.Element {
         >
           ⚙️
         </button>
+        <button
+          className={active === 'admin' ? 'tab active' : 'tab'}
+          onClick={() => setActive('admin')}
+          aria-label="Admin"
+        >
+          🛠️
+        </button>
       </div>
       <div className="content">
         {active === 'info' && <InfoTab />}
         {active === 'chat' && <ChatTab />}
         {active === 'settings' && <SettingsTab />}
+        {active === 'admin' && <AdminTab />}
       </div>
     </div>
   );

--- a/src/ui/tabs/AdminTab.tsx
+++ b/src/ui/tabs/AdminTab.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+import { botControls } from '@/state/bots';
+
+export function AdminTab(): JSX.Element {
+  const [count, setCount] = useState(0);
+  const [enabled, setEnabled] = useState(false);
+
+  const onCountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = Math.max(0, Math.min(50, Number(e.target.value)));
+    setCount(value);
+    if (enabled) botControls.setCount(value);
+  };
+
+  const onEnableChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const checked = e.target.checked;
+    setEnabled(checked);
+    botControls.setEnabled(checked);
+    if (checked) botControls.setCount(count);
+  };
+
+  return (
+    <div className="admin-tab">
+      <h2>Admin</h2>
+      <div>
+        <h3>Bot Avatars</h3>
+        <label>
+          Bot count:
+          <input type="number" min={0} max={50} value={count} onChange={onCountChange} />
+        </label>
+        <label>
+          <input type="checkbox" checked={enabled} onChange={onEnableChange} /> Enable Bot Avatars
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/src/world/bots/BotManager.ts
+++ b/src/world/bots/BotManager.ts
@@ -1,0 +1,92 @@
+import * as THREE from 'three';
+import { AvatarFactory } from '@/world/entities';
+
+export interface BotManagerInit {
+  scene: THREE.Scene;
+  glassRoomRef: { room: THREE.Group; w: number; d: number };
+  avatarFactory: AvatarFactory;
+}
+
+/**
+ * Manages simple bot avatars inside the glass room.
+ */
+export class BotManager {
+  private scene?: THREE.Scene;
+  private room?: THREE.Group;
+  private w = 0;
+  private d = 0;
+  private factory?: AvatarFactory;
+  private bots: THREE.Group[] = [];
+  private enabled = false;
+  private count = 0;
+  readonly max = 50;
+
+  /** Initialize manager with scene references. */
+  init({ scene, glassRoomRef, avatarFactory }: BotManagerInit): void {
+    this.scene = scene;
+    this.room = glassRoomRef.room;
+    this.w = glassRoomRef.w;
+    this.d = glassRoomRef.d;
+    this.factory = avatarFactory;
+  }
+
+  /** Enable or disable bot spawning. */
+  setEnabled(enabled: boolean): void {
+    if (this.enabled === enabled) return;
+    this.enabled = enabled;
+    if (enabled) this.apply();
+    else this.clear();
+  }
+
+  /** Set desired bot count (clamped 0..50). */
+  setCount(n: number): void {
+    const c = Math.min(this.max, Math.max(0, n));
+    this.count = c;
+    if (this.enabled) this.apply();
+  }
+
+  /** Update bots each frame. */
+  update(dt: number): void {
+    if (!this.enabled) return;
+    for (const bot of this.bots) {
+      bot.rotation.y += dt * 0.1;
+    }
+  }
+
+  /** Remove all bots and clear references. */
+  dispose(): void {
+    this.clear();
+    this.scene = undefined;
+    this.room = undefined;
+    this.factory = undefined;
+  }
+
+  private apply(): void {
+    if (!this.scene || !this.room || !this.factory) return;
+    while (this.bots.length < this.count) {
+      const bot = this.factory.create();
+      const index = this.bots.length + 1;
+      bot.userData.name = `Bot - #${index}`;
+      const cx = this.room.position.x;
+      const cz = this.room.position.z;
+      const x = cx + (Math.random() - 0.5) * this.w;
+      const z = cz + (Math.random() - 0.5) * this.d;
+      bot.position.set(x, 1, z);
+      this.scene.add(bot);
+      this.bots.push(bot);
+    }
+    while (this.bots.length > this.count) {
+      const bot = this.bots.pop();
+      if (bot) this.scene.remove(bot);
+    }
+  }
+
+  private clear(): void {
+    if (this.scene) {
+      for (const bot of this.bots) {
+        this.scene.remove(bot);
+      }
+    }
+    this.bots = [];
+  }
+}


### PR DESCRIPTION
## Summary
- add Admin tab to Dock with bot controls
- implement BotManager to spawn/remove up to 50 bots in glass room
- wire BotManager into world update loop and expose controls to UI

## Testing
- `npm test` *(fails: Missing script)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689cfa34baa48324a3f1d6321ea96218