### PR TITLE
feat: admin role switcher and teleport

### DIFF
--- a/src/domain/roles.ts
+++ b/src/domain/roles.ts
@@ -12,6 +12,7 @@ export interface AvatarUser {
   isLocal?: boolean;
   isBot?: boolean;
   color?: string;
+  isAdmin?: boolean;
 }
 
 export const RoleLabels: Record<Role, { label: string; color: string }> = {
@@ -22,4 +23,9 @@ export const RoleLabels: Record<Role, { label: string; color: string }> = {
 export const RoleCapabilities: Record<Role, string[]> = {
   instructor: [],
   learner: [],
+};
+
+export const RoleSubRolesMap: Record<Role, SubRole[]> = {
+  instructor: ['instructor', 'co_instructor', 'learning_assistant'],
+  learner: ['vip', 'pro', 'basic'],
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -16,6 +16,8 @@ import { runtime } from '@/state/runtime';
 import { BotManager } from '@/world/bots/BotManager';
 import { botControls } from '@/state/bots';
 import * as nameTags from '@/world/nameTags';
+import { setWorldRefs } from '@/world/spawn';
+import { onTeleportLocal } from '@/world/worldBus';
 import '@/styles/global.css';
 
 // Bootstrap React
@@ -57,6 +59,8 @@ function initializeThreeWorld() {
   const roomPos = new THREE.Vector3(planeSize / 2 - STAGE_W / 2, 0, 0);
   const { room: glassRoom, block: roomBlock } = createGlassRoom(scene, { w: STAGE_W, d: STAGE_D, position: roomPos });
 
+  setWorldRefs({ stage, glassRoom, dims: { STAGE_W, STAGE_D, STAGE_H, planeSize } });
+
   // NFT Bina: garden sol-orta; merkez (5,0,135)
   const nftPos = new THREE.Vector3(5, 0, 135);
   const { building: nftBuilding, block: buildingBlock } = createNftBuilding(scene, { w: 60, d: 40, h: 22, position: nftPos, doorRatio: 0.35 });
@@ -72,6 +76,14 @@ function initializeThreeWorld() {
   avatar.rotation.y = -Math.PI / 2;
   camera.position.set(avatar.position.x + 12, avatar.position.y + 8, avatar.position.z + 0);
   controls.target.copy(avatar.position);
+
+  onTeleportLocal(({ position, rotationY }) => {
+    avatar.position.set(position.x, position.y, position.z);
+    if (typeof rotationY === 'number') avatar.rotation.y = rotationY;
+    const offset = camera.position.clone().sub(controls.target);
+    controls.target.copy(avatar.position);
+    camera.position.copy(avatar.position.clone().add(offset));
+  });
 
   // Portal (mor binanın karşısı)
   const portalPos = new THREE.Vector3(-5, 0, -135);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -115,7 +115,7 @@ function initializeThreeWorld() {
   });
 
   // Instructor teleprompter + timer display
-  const teleprompter = createTeleprompterRig(THREE, scene, { stage, stageTopY });
+  const teleprompter = createTeleprompterRig(THREE, scene);
 
   // Bot avatars
   const botManager = new BotManager();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -52,7 +52,7 @@ function initializeThreeWorld() {
   const { scene, camera, renderer, controls, amb, sun, adaptiveQuality } = createSceneSetup();
   const keys = createInput();
 
-  const { planeSize, stage, STAGE_W, STAGE_D, STAGE_H, insideStageXZ, groundYAt, boardBlock, boardZCenter, boardYCenter } = createGarden(scene);
+  const { planeSize, stage, STAGE_W, STAGE_D, STAGE_H, insideStageXZ, groundYAt, boardBlock, stageBlock, boardZCenter, boardYCenter } = createGarden(scene);
   const stageTopY = stage.position.y + STAGE_H / 2;
 
   // Camlı oda: sahne ile aynı boyut; haritanın en sağ kenarı (varsayılan)
@@ -205,7 +205,8 @@ function initializeThreeWorld() {
       stageTopY,
       roomBlock,
       buildingBlock,
-      boardBlock
+      boardBlock,
+      stageBlock
     });
     runtime.avatar.x = avatar.position.x;
     runtime.avatar.y = avatar.position.y;

--- a/src/scene/teleprompter/createTeleprompterRig.ts
+++ b/src/scene/teleprompter/createTeleprompterRig.ts
@@ -28,7 +28,7 @@ export function createTeleprompterRig(
   scene: THREE.Scene,
   opts: TeleprompterRigOptions = {}
 ): TeleprompterRig {
-  const { position = { x: -120, y: 18, z: 23 }, scale = 3 } = opts;
+  const { position = { x: -120, y: 20, z: 23 }, scale = 6 } = opts;
   const group = new THREE.Group();
   group.position.set(position.x, position.y, position.z);
   group.scale.set(scale, scale, scale);
@@ -68,11 +68,11 @@ export function createTeleprompterRig(
   group.add(back);
 
   // support pole between y=16 and y=18 (world units)
-  const poleH = 2 / scale;
+  const poleH = 4 / scale;
   const poleGeom = new THREE.CylinderGeometry(0.05 / scale, 0.05 / scale, poleH);
   const poleMat = new THREE.MeshStandardMaterial({ color: 0x000000 });
   const pole = new THREE.Mesh(poleGeom, poleMat);
-  pole.position.y = -poleH / 2;
+  pole.position.y = -poleH / 0.8;
   group.add(pole);
 
   let lastText = '';

--- a/src/scene/teleprompter/createTeleprompterRig.ts
+++ b/src/scene/teleprompter/createTeleprompterRig.ts
@@ -28,7 +28,7 @@ export function createTeleprompterRig(
   scene: THREE.Scene,
   opts: TeleprompterRigOptions = {}
 ): TeleprompterRig {
-  const { position = { x: -120, y: 16, z: 23 }, scale = 3 } = opts;
+  const { position = { x: -120, y: 18, z: 23 }, scale = 3 } = opts;
   const group = new THREE.Group();
   group.position.set(position.x, position.y, position.z);
   group.scale.set(scale, scale, scale);
@@ -59,6 +59,21 @@ export function createTeleprompterRig(
   // place the monitor at the group's origin
   screen.rotation.y = -Math.PI / 2; // face instructor (-X)
   group.add(screen);
+
+  // backside of the monitor
+  const backMat = new THREE.MeshBasicMaterial({ color: 0x000000 });
+  const back = new THREE.Mesh(screenGeom, backMat);
+  back.rotation.y = Math.PI / 2;
+  back.position.x = 0.02 / scale; // slight offset back
+  group.add(back);
+
+  // support pole between y=16 and y=18 (world units)
+  const poleH = 2 / scale;
+  const poleGeom = new THREE.CylinderGeometry(0.05 / scale, 0.05 / scale, poleH);
+  const poleMat = new THREE.MeshStandardMaterial({ color: 0x000000 });
+  const pole = new THREE.Mesh(poleGeom, poleMat);
+  pole.position.y = -poleH / 2;
+  group.add(pole);
 
   let lastText = '';
   function setText(t: string) {

--- a/src/state/userStore.ts
+++ b/src/state/userStore.ts
@@ -1,5 +1,5 @@
 import { useSyncExternalStore } from 'react';
-import { AvatarUser } from '@/domain/roles';
+import { AvatarUser, Role, SubRole } from '@/domain/roles';
 
 type Listener = () => void;
 
@@ -56,7 +56,7 @@ export const userStore = {
 };
 
 // Initialize with a default local user
-setLocalUser({ id: 'local-1', name: 'macaris64', role: 'learner', subRole: 'pro' });
+setLocalUser({ id: 'local-1', name: 'macaris64', role: 'learner', subRole: 'pro', isAdmin: true });
 
 export function useUsers(): AvatarUser[] {
   return useSyncExternalStore(userStore.subscribe, userStore.all);
@@ -68,4 +68,16 @@ export function useLocalUser(): AvatarUser | null {
 
 export function useOnlineCount(): number {
   return useSyncExternalStore(userStore.subscribe, userStore.count);
+}
+
+export function updateLocalRole(role: Role, subRole?: SubRole): void {
+  if (!localId) return;
+  const current = users.get(localId);
+  if (!current) return;
+  users.set(localId, { ...current, role, subRole });
+  emit();
+}
+
+export function isLocalAdmin(): boolean {
+  return Boolean(getLocal()?.isAdmin);
 }

--- a/src/ui/Dock.tsx
+++ b/src/ui/Dock.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { useLocalUser } from '@/state/userStore';
 import { InfoTab } from '@/ui/tabs/InfoTab';
 import { ChatTab } from '@/ui/tabs/ChatTab';
 import { SettingsTab } from '@/ui/tabs/SettingsTab';
@@ -9,19 +10,28 @@ type Tab = 'info' | 'chat' | 'settings' | 'admin';
 
 export function Dock(): JSX.Element {
   const [active, setActive] = useState<Tab>('info');
+  const local = useLocalUser();
+  const isAdmin = local?.isAdmin;
 
-  const handleKey = useCallback((e: KeyboardEvent) => {
-    if (!e.altKey) return;
-    if (e.key === '1') setActive('info');
-    if (e.key === '2') setActive('chat');
-    if (e.key === '3') setActive('settings');
-    if (e.key === '4') setActive('admin');
-  }, []);
+  const handleKey = useCallback(
+    (e: KeyboardEvent) => {
+      if (!e.altKey) return;
+      if (e.key === '1') setActive('info');
+      if (e.key === '2') setActive('chat');
+      if (e.key === '3') setActive('settings');
+      if (e.key === '4' && isAdmin) setActive('admin');
+    },
+    [isAdmin]
+  );
 
   useEffect(() => {
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
   }, [handleKey]);
+
+  useEffect(() => {
+    if (!isAdmin && active === 'admin') setActive('info');
+  }, [isAdmin, active]);
 
   return (
     <div className="dock" id="dock">
@@ -47,19 +57,21 @@ export function Dock(): JSX.Element {
         >
           ⚙️
         </button>
-        <button
-          className={active === 'admin' ? 'tab active' : 'tab'}
-          onClick={() => setActive('admin')}
-          aria-label="Admin"
-        >
-          🛠️
-        </button>
+        {isAdmin && (
+          <button
+            className={active === 'admin' ? 'tab active' : 'tab'}
+            onClick={() => setActive('admin')}
+            aria-label="Admin"
+          >
+            🛠️
+          </button>
+        )}
       </div>
       <div className="content">
         {active === 'info' && <InfoTab />}
         {active === 'chat' && <ChatTab />}
         {active === 'settings' && <SettingsTab />}
-        {active === 'admin' && <AdminTab />}
+        {isAdmin && active === 'admin' && <AdminTab />}
       </div>
     </div>
   );

--- a/src/ui/admin/AdminRoleSwitcher.tsx
+++ b/src/ui/admin/AdminRoleSwitcher.tsx
@@ -1,0 +1,46 @@
+import { useState, useEffect } from 'react';
+import { Role, SubRole, RoleSubRolesMap } from '@/domain/roles';
+import { useLocalUser, updateLocalRole } from '@/state/userStore';
+import { requestTeleportToRole } from '@/world/spawn';
+
+export function AdminRoleSwitcher(): JSX.Element {
+  const local = useLocalUser();
+  const [role, setRole] = useState<Role>(local?.role ?? 'learner');
+  const [subRole, setSubRole] = useState<SubRole>(
+    (local?.subRole as SubRole) ?? RoleSubRolesMap[role][0]
+  );
+
+  useEffect(() => {
+    const subs = RoleSubRolesMap[role];
+    if (!subs.includes(subRole)) setSubRole(subs[0]);
+  }, [role, subRole]);
+
+  const apply = () => {
+    updateLocalRole(role, subRole);
+    requestTeleportToRole(role);
+  };
+
+  return (
+    <div className="admin-role-switcher">
+      <label>
+        Role:
+        <select value={role} onChange={(e) => setRole(e.target.value as Role)}>
+          <option value="learner">Learner</option>
+          <option value="instructor">Instructor</option>
+        </select>
+      </label>
+      <label>
+        SubRole:
+        <select value={subRole} onChange={(e) => setSubRole(e.target.value as SubRole)}>
+          {RoleSubRolesMap[role].map((sr) => (
+            <option key={sr} value={sr}>
+              {sr}
+            </option>
+          ))}
+        </select>
+      </label>
+      <button onClick={apply}>Apply</button>
+    </div>
+  );
+}
+

--- a/src/ui/tabs/AdminTab.tsx
+++ b/src/ui/tabs/AdminTab.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { botControls } from '@/state/bots';
+import { AdminRoleSwitcher } from '@/ui/admin/AdminRoleSwitcher';
 
 export function AdminTab(): JSX.Element {
   const [count, setCount] = useState(0);
@@ -21,6 +22,10 @@ export function AdminTab(): JSX.Element {
   return (
     <div className="admin-tab">
       <h2>Admin</h2>
+      <div>
+        <h3>Role & Spawn</h3>
+        <AdminRoleSwitcher />
+      </div>
       <div>
         <h3>Bot Avatars</h3>
         <label>

--- a/src/world/constraints.ts
+++ b/src/world/constraints.ts
@@ -1,0 +1,11 @@
+import { Role } from '@/domain/roles';
+
+export function canEnterStage(role: Role): boolean {
+  return role === 'instructor'; // future logic
+}
+
+export function attachRoleConstraints(_getLocalRole: () => Role) {
+  // TODO: integrate with movement/collision code:
+  // - If learner and insideStageXZ → block
+  // - If instructor, allow on-stage; disallow leaving stage (downwards) if required
+}

--- a/src/world/entities.ts
+++ b/src/world/entities.ts
@@ -120,7 +120,7 @@ export function updateAvatar(
 ): void {
   if (!avatar) return;
   
-  const { insideStageXZ, groundYAt, planeSize, stageTopY, roomBlock, buildingBlock, boardBlock } = helpers;
+  const { groundYAt, planeSize, roomBlock, buildingBlock, boardBlock } = helpers;
   const AVATAR_SIZE = 2;
 
   const forward = new THREE.Vector3();
@@ -168,12 +168,6 @@ export function updateAvatar(
   avatar.position.z = Math.min(Math.max(avatar.position.z, minZ), maxZ);
 
   // TODO: apply role-based stage constraints from constraints.ts
-  if (insideStageXZ(avatar.position.x, avatar.position.z) && (avatar.position.y - AVATAR_SIZE / 2) < (stageTopY + 0.01)) {
-    avatar.position.x = prev.x;
-    avatar.position.z = prev.z;
-    vel.x = 0;
-    vel.z = 0;
-  }
 
   if (typeof roomBlock === 'function') roomBlock(avatar.position, prev, AVATAR_SIZE / 2);
   if (typeof buildingBlock === 'function') buildingBlock(avatar.position, prev, AVATAR_SIZE / 2);

--- a/src/world/entities.ts
+++ b/src/world/entities.ts
@@ -9,6 +9,7 @@ export interface AvatarHelpers {
   roomBlock?: (pos: THREE.Vector3, prev: THREE.Vector3, half?: number) => void;
   buildingBlock?: (pos: THREE.Vector3, prev: THREE.Vector3, half?: number) => void;
   boardBlock?: (pos: THREE.Vector3, prev: THREE.Vector3, half?: number) => void;
+  stageBlock?: (pos: THREE.Vector3, prev: THREE.Vector3, half?: number) => void;
 }
 
 export interface AvatarMaterials {
@@ -120,7 +121,7 @@ export function updateAvatar(
 ): void {
   if (!avatar) return;
   
-  const { groundYAt, planeSize, roomBlock, buildingBlock, boardBlock } = helpers;
+  const { groundYAt, planeSize, roomBlock, buildingBlock, boardBlock, stageBlock } = helpers;
   const AVATAR_SIZE = 2;
 
   const forward = new THREE.Vector3();
@@ -169,6 +170,7 @@ export function updateAvatar(
 
   // TODO: apply role-based stage constraints from constraints.ts
 
+  if (typeof stageBlock === 'function') stageBlock(avatar.position, prev, AVATAR_SIZE / 2);
   if (typeof roomBlock === 'function') roomBlock(avatar.position, prev, AVATAR_SIZE / 2);
   if (typeof buildingBlock === 'function') buildingBlock(avatar.position, prev, AVATAR_SIZE / 2);
   if (typeof boardBlock === 'function') boardBlock(avatar.position, prev, AVATAR_SIZE / 2);

--- a/src/world/entities.ts
+++ b/src/world/entities.ts
@@ -167,6 +167,7 @@ export function updateAvatar(
   avatar.position.x = Math.min(Math.max(avatar.position.x, minX), maxX);
   avatar.position.z = Math.min(Math.max(avatar.position.z, minZ), maxZ);
 
+  // TODO: apply role-based stage constraints from constraints.ts
   if (insideStageXZ(avatar.position.x, avatar.position.z) && (avatar.position.y - AVATAR_SIZE / 2) < (stageTopY + 0.01)) {
     avatar.position.x = prev.x;
     avatar.position.z = prev.z;

--- a/src/world/garden.ts
+++ b/src/world/garden.ts
@@ -81,7 +81,7 @@ export function createGarden(scene: THREE.Scene): GardenSetup {
   }
 
   const groundYAt = (x: number, z: number, half = 1): number => {
-    if (insideStageXZ(x, z, half)) return 9999;
+    if (insideStageXZ(x, z, half)) return stage.position.y + STAGE_H / 2;
     return insideEllipse(x, z) ? 0 : 9999;
   };
 

--- a/src/world/garden.ts
+++ b/src/world/garden.ts
@@ -11,6 +11,7 @@ export interface GardenSetup {
   insideStageXZ: (x: number, z: number, half?: number) => boolean;
   groundYAt: (x: number, z: number, half?: number) => number;
   boardBlock: (pos: THREE.Vector3, prev: THREE.Vector3, half?: number) => void;
+  stageBlock: (pos: THREE.Vector3, prev: THREE.Vector3, half?: number) => void;
   board: THREE.Mesh;
   boardSize: number;
   boardZCenter: number;
@@ -66,6 +67,20 @@ export function createGarden(scene: THREE.Scene): GardenSetup {
     if (sidePrev !== 0 && sideNow !== 0 && sidePrev !== sideNow) { pos.x = prev.x; return; }
   }
 
+  function stageBlock(pos: THREE.Vector3, prev: THREE.Vector3, half = 1) {
+    const top = stage.position.y + STAGE_H / 2;
+    const wasOnStage = prev.y >= top - half && insideStageXZ(prev.x, prev.z, half);
+    if (!wasOnStage) return;
+
+    const sxMin = stage.position.x - STAGE_W / 2 + half;
+    const sxMax = stage.position.x + STAGE_W / 2 - half;
+    const szMin = stage.position.z - STAGE_D / 2 + half;
+    const szMax = stage.position.z + STAGE_D / 2 - half;
+
+    pos.x = Math.min(Math.max(pos.x, sxMin), sxMax);
+    pos.z = Math.min(Math.max(pos.z, szMin), szMax);
+  }
+
   function insideStageXZ(x: number, z: number, half = 1): boolean {
     const sxMin = stage.position.x - STAGE_W / 2 - half,
       sxMax = stage.position.x + STAGE_W / 2 + half,
@@ -92,10 +107,11 @@ export function createGarden(scene: THREE.Scene): GardenSetup {
     stage, 
     STAGE_W, 
     STAGE_D, 
-    STAGE_H, 
-    insideStageXZ, 
-    groundYAt, 
+    STAGE_H,
+    insideStageXZ,
+    groundYAt,
     boardBlock,
+    stageBlock,
     board,
     boardSize,
     boardZCenter,

--- a/src/world/spawn.ts
+++ b/src/world/spawn.ts
@@ -1,0 +1,43 @@
+import * as THREE from 'three';
+import { Role } from '@/domain/roles';
+import { emitTeleportLocal } from './worldBus';
+
+interface WorldRefs {
+  stage: THREE.Object3D;
+  glassRoom: THREE.Object3D;
+  dims: { STAGE_W: number; STAGE_D: number; STAGE_H: number; planeSize: number };
+}
+
+let refs: WorldRefs | null = null;
+const AVATAR_HALF = 1;
+
+export function setWorldRefs(r: WorldRefs): void {
+  refs = r;
+}
+
+export function getInstructorSpawn() {
+  if (!refs) throw new Error('World refs not set');
+  const { stage, dims } = refs;
+  const position = {
+    x: stage.position.x,
+    y: stage.position.y + dims.STAGE_H / 2 + AVATAR_HALF,
+    z: stage.position.z - dims.STAGE_D / 2 + 2,
+  };
+  return { position, rotationY: 0 };
+}
+
+export function getLearnerSpawn() {
+  if (!refs) throw new Error('World refs not set');
+  const { glassRoom } = refs;
+  const position = {
+    x: glassRoom.position.x,
+    y: AVATAR_HALF,
+    z: glassRoom.position.z,
+  };
+  return { position, rotationY: -Math.PI / 2 };
+}
+
+export function requestTeleportToRole(role: Role) {
+  const p = role === 'instructor' ? getInstructorSpawn() : getLearnerSpawn();
+  emitTeleportLocal(p);
+}

--- a/src/world/spawn.ts
+++ b/src/world/spawn.ts
@@ -17,12 +17,8 @@ export function setWorldRefs(r: WorldRefs): void {
 
 export function getInstructorSpawn() {
   if (!refs) throw new Error('World refs not set');
-  const { stage, dims } = refs;
-  const position = {
-    x: stage.position.x,
-    y: stage.position.y + dims.STAGE_H / 2 + AVATAR_HALF,
-    z: stage.position.z - dims.STAGE_D / 2 + 2,
-  };
+  const { dims } = refs;
+  const position = { x: -150, y: dims.STAGE_H + AVATAR_HALF, z: 23 };
   return { position, rotationY: 0 };
 }
 

--- a/src/world/worldBus.ts
+++ b/src/world/worldBus.ts
@@ -1,0 +1,15 @@
+export type TeleportLocalPayload = {
+  position: { x: number; y: number; z: number };
+  rotationY?: number;
+};
+
+const teleportLocalListeners = new Set<(p: TeleportLocalPayload) => void>();
+
+export function emitTeleportLocal(p: TeleportLocalPayload): void {
+  for (const fn of teleportLocalListeners) fn(p);
+}
+
+export function onTeleportLocal(fn: (p: TeleportLocalPayload) => void): () => void {
+  teleportLocalListeners.add(fn);
+  return () => teleportLocalListeners.delete(fn);
+}


### PR DESCRIPTION
## Summary
- add `isAdmin` to user model and role helpers
- let admins switch roles and spawn accordingly
- introduce teleport bus, spawn helpers, and future role constraints stub

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689d091e9aa48324b4f466bacd86d4c1