### PR TITLE
feat: add tree-based admin panel with local routing

### DIFF
--- a/src/ui/Dock.tsx
+++ b/src/ui/Dock.tsx
@@ -3,7 +3,7 @@ import { useLocalUser } from '@/state/userStore';
 import { InfoTab } from '@/ui/tabs/InfoTab';
 import { ChatTab } from '@/ui/tabs/ChatTab';
 import { SettingsTab } from '@/ui/tabs/SettingsTab';
-import { AdminTab } from '@/ui/tabs/AdminTab';
+import AdminPanel from '@/ui/admin/AdminPanel';
 import './dock.css';
 
 type Tab = 'info' | 'chat' | 'settings' | 'admin';
@@ -71,7 +71,7 @@ export function Dock(): JSX.Element {
         {active === 'info' && <InfoTab />}
         {active === 'chat' && <ChatTab />}
         {active === 'settings' && <SettingsTab />}
-        {isAdmin && active === 'admin' && <AdminTab />}
+        {isAdmin && active === 'admin' && <AdminPanel />}
       </div>
     </div>
   );

--- a/src/ui/admin/AdminBotsPanel.tsx
+++ b/src/ui/admin/AdminBotsPanel.tsx
@@ -1,8 +1,7 @@
 import { useState } from 'react';
 import { botControls } from '@/state/bots';
-import { AdminRoleSwitcher } from '@/ui/admin/AdminRoleSwitcher';
 
-export function AdminTab(): JSX.Element {
+export function AdminBotsPanel(): JSX.Element {
   const [count, setCount] = useState(0);
   const [enabled, setEnabled] = useState(false);
 
@@ -20,22 +19,14 @@ export function AdminTab(): JSX.Element {
   };
 
   return (
-    <div className="admin-tab">
-      <h2>Admin</h2>
-      <div>
-        <h3>Role & Spawn</h3>
-        <AdminRoleSwitcher />
-      </div>
-      <div>
-        <h3>Bot Avatars</h3>
-        <label>
-          Bot count:
-          <input type="number" min={0} max={50} value={count} onChange={onCountChange} />
-        </label>
-        <label>
-          <input type="checkbox" checked={enabled} onChange={onEnableChange} /> Enable Bot Avatars
-        </label>
-      </div>
+    <div className="admin-bots-panel">
+      <label>
+        Bot count:
+        <input type="number" min={0} max={50} value={count} onChange={onCountChange} />
+      </label>
+      <label>
+        <input type="checkbox" checked={enabled} onChange={onEnableChange} /> Enable Bot Avatars
+      </label>
     </div>
   );
 }

--- a/src/ui/admin/AdminPanel.tsx
+++ b/src/ui/admin/AdminPanel.tsx
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+import { AdminRoute } from './adminRoutes';
+import AdminHome from './views/AdminHome';
+import RoleSpawnView from './views/RoleSpawnView';
+import BotAvatarsView from './views/BotAvatarsView';
+import './admin.css';
+
+export default function AdminPanel(): JSX.Element {
+  const [route, setRoute] = useState<AdminRoute>(AdminRoute.Home);
+
+  if (route === AdminRoute.RoleSpawn) {
+    return <RoleSpawnView onBack={() => setRoute(AdminRoute.Home)} />;
+  }
+
+  if (route === AdminRoute.BotAvatars) {
+    return <BotAvatarsView onBack={() => setRoute(AdminRoute.Home)} />;
+  }
+
+  return <AdminHome onNavigate={setRoute} />;
+}

--- a/src/ui/admin/admin.css
+++ b/src/ui/admin/admin.css
@@ -1,0 +1,49 @@
+.admin-home-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.admin-home-item {
+  width: 100%;
+  display: flex;
+  align-items: flex-start;
+  background: none;
+  border: none;
+  color: inherit;
+  padding: 8px 4px;
+  cursor: pointer;
+  text-align: left;
+}
+.admin-home-item:hover,
+.admin-home-item:focus {
+  background: rgba(130,180,255,.18);
+}
+.admin-home-item .icon {
+  margin-right: 8px;
+  font-size: 20px;
+}
+.admin-home-item .text {
+  flex: 1;
+}
+.admin-home-item .title {
+  font-weight: 600;
+}
+.admin-home-item .desc {
+  font-size: 13px;
+  opacity: 0.8;
+}
+.admin-home-item .chevron {
+  margin-left: 8px;
+}
+.admin-detail-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+}
+.admin-detail-header .back-btn {
+  margin-right: 8px;
+}
+.admin-detail-header h3 {
+  margin: 0;
+  font-size: 16px;
+}

--- a/src/ui/admin/adminRoutes.ts
+++ b/src/ui/admin/adminRoutes.ts
@@ -1,0 +1,5 @@
+export enum AdminRoute {
+  Home = 'home',
+  RoleSpawn = 'role_spawn',
+  BotAvatars = 'bot_avatars',
+}

--- a/src/ui/admin/views/AdminHome.tsx
+++ b/src/ui/admin/views/AdminHome.tsx
@@ -1,0 +1,39 @@
+import { AdminRoute } from '../adminRoutes';
+
+type Props = {
+  onNavigate: (route: AdminRoute) => void;
+};
+
+export default function AdminHome({ onNavigate }: Props): JSX.Element {
+  return (
+    <div className="admin-home">
+      <h2>Admin</h2>
+      <ul className="admin-home-list">
+        <li>
+          <button className="admin-home-item" onClick={() => onNavigate(AdminRoute.RoleSpawn)}>
+            <span className="icon">🧭</span>
+            <div className="text">
+              <div className="title">Role Spawn</div>
+              <div className="desc">
+                Temporarily become Learner/Instructor and teleport to the appropriate spawn point.
+              </div>
+            </div>
+            <span className="chevron">›</span>
+          </button>
+        </li>
+        <li>
+          <button className="admin-home-item" onClick={() => onNavigate(AdminRoute.BotAvatars)}>
+            <span className="icon">🤖</span>
+            <div className="text">
+              <div className="title">Bot Avatars</div>
+              <div className="desc">
+                Spawn/remove up to 50 bot avatars in the glassroom. Names: Bot - #n.
+              </div>
+            </div>
+            <span className="chevron">›</span>
+          </button>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/src/ui/admin/views/BotAvatarsView.tsx
+++ b/src/ui/admin/views/BotAvatarsView.tsx
@@ -1,0 +1,21 @@
+import { AdminBotsPanel } from '../AdminBotsPanel';
+
+type Props = {
+  onBack: () => void;
+};
+
+export default function BotAvatarsView({ onBack }: Props): JSX.Element {
+  return (
+    <div className="bot-avatars-view">
+      <div className="admin-detail-header">
+        <button className="back-btn" onClick={onBack}>
+          ← Back
+        </button>
+        <h3>Admin / Bot Avatars</h3>
+      </div>
+      <div className="admin-detail-content">
+        <AdminBotsPanel />
+      </div>
+    </div>
+  );
+}

--- a/src/ui/admin/views/RoleSpawnView.tsx
+++ b/src/ui/admin/views/RoleSpawnView.tsx
@@ -1,0 +1,21 @@
+import { AdminRoleSwitcher } from '../AdminRoleSwitcher';
+
+type Props = {
+  onBack: () => void;
+};
+
+export default function RoleSpawnView({ onBack }: Props): JSX.Element {
+  return (
+    <div className="role-spawn-view">
+      <div className="admin-detail-header">
+        <button className="back-btn" onClick={onBack}>
+          ← Back
+        </button>
+        <h3>Admin / Role Spawn</h3>
+      </div>
+      <div className="admin-detail-content">
+        <AdminRoleSwitcher />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- restructure admin tools into home list + detail views
- add local admin routes and wire new AdminPanel into Dock
- reuse RoleSwitcher and Bot avatar controls

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689d17dbd30c832490717abdad43d946