### PR TITLE
feat: add performance presets

### DIFF
--- a/src/engine/perf/adaptiveQualityBridge.ts
+++ b/src/engine/perf/adaptiveQualityBridge.ts
@@ -1,0 +1,43 @@
+import * as THREE from 'three';
+
+export interface AdaptiveQualityBridge {
+  loop: () => void;
+  setBounds: (min: number, max: number) => void;
+}
+
+export function createAdaptiveQualityBridge(
+  renderer: THREE.WebGLRenderer,
+  sun: THREE.DirectionalLight
+): AdaptiveQualityBridge {
+  let frameCount = 0;
+  let lastTime = performance.now();
+  let minRatio = 0.75;
+  let maxRatio = 1.75;
+  let targetPR = Math.min(maxRatio, window.devicePixelRatio || 1);
+  renderer.setPixelRatio(targetPR);
+
+  function setBounds(min: number, max: number) {
+    minRatio = min;
+    maxRatio = max;
+    targetPR = Math.min(Math.max(targetPR, minRatio), maxRatio);
+    renderer.setPixelRatio(targetPR);
+  }
+
+  function loop() {
+    frameCount++;
+    const now = performance.now();
+    if (now - lastTime > 1500) {
+      const fps = frameCount / ((now - lastTime) / 1000);
+      frameCount = 0;
+      lastTime = now;
+      if (fps < 45) targetPR = Math.max(minRatio, targetPR - 0.1);
+      else if (fps > 58) targetPR = Math.min(maxRatio, targetPR + 0.05);
+      renderer.setPixelRatio(targetPR);
+      const m = targetPR >= 1.2 ? 2048 : targetPR >= 1.0 ? 1536 : 1024;
+      sun.shadow.mapSize.set(m, m);
+      sun.shadow.needsUpdate = true;
+    }
+  }
+
+  return { loop, setBounds };
+}

--- a/src/engine/perf/applyPerformancePreset.ts
+++ b/src/engine/perf/applyPerformancePreset.ts
@@ -1,0 +1,59 @@
+import * as THREE from 'three';
+import { PerformancePreset } from '@/types/preferences';
+
+export interface EngineHandles {
+  renderer: THREE.WebGLRenderer;
+  sun?: THREE.DirectionalLight;
+  worldfx?: { setThrottleHz?: (hz: number) => void };
+  trees?: { setDensity?: (ratio: number) => void };
+  avatars?: { setLOD?: (mode: 'low' | 'medium' | 'high') => void };
+  marquee?: { setResolution?: (w: number, h: number) => void };
+  adaptiveQuality?: { setBounds?: (min: number, max: number) => void };
+}
+
+export function applyPerformancePreset(preset: PerformancePreset, handles: EngineHandles): void {
+  try {
+    switch (preset) {
+      case 'low':
+        handles.adaptiveQuality?.setBounds?.(0.75, 1.0);
+        handles.renderer.shadowMap.enabled = false;
+        handles.sun && (handles.sun.castShadow = false);
+        handles.worldfx?.setThrottleHz?.(1);
+        handles.trees?.setDensity?.(0.0);
+        handles.avatars?.setLOD?.('low');
+        handles.marquee?.setResolution?.(512, 128);
+        break;
+      case 'medium':
+        handles.adaptiveQuality?.setBounds?.(0.9, 1.25);
+        handles.renderer.shadowMap.enabled = true;
+        if (handles.sun) {
+          handles.sun.castShadow = true;
+          handles.sun.shadow.mapSize.set(1536, 1536);
+          handles.renderer.shadowMap.type = THREE.PCFShadowMap;
+          handles.sun.shadow.needsUpdate = true;
+        }
+        handles.worldfx?.setThrottleHz?.(12);
+        handles.trees?.setDensity?.(0.5);
+        handles.avatars?.setLOD?.('medium');
+        handles.marquee?.setResolution?.(1024, 256);
+        break;
+      case 'high':
+      default:
+        handles.adaptiveQuality?.setBounds?.(1.2, 1.75);
+        handles.renderer.shadowMap.enabled = true;
+        if (handles.sun) {
+          handles.sun.castShadow = true;
+          handles.sun.shadow.mapSize.set(2048, 2048);
+          handles.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+          handles.sun.shadow.needsUpdate = true;
+        }
+        handles.worldfx?.setThrottleHz?.(0);
+        handles.trees?.setDensity?.(1.0);
+        handles.avatars?.setLOD?.('high');
+        handles.marquee?.setResolution?.(1024, 256);
+        break;
+    }
+  } catch {
+    // swallow errors to keep defensive
+  }
+}

--- a/src/engine/perf/presets.ts
+++ b/src/engine/perf/presets.ts
@@ -1,0 +1,14 @@
+import { EngineHandles, applyPerformancePreset } from './applyPerformancePreset';
+import { userStore } from '@/state/userStore';
+
+let handles: EngineHandles | null = null;
+
+export function setEngineHandles(h: EngineHandles): void {
+  handles = h;
+}
+
+export function applyCurrentPreset(): void {
+  if (!handles) return;
+  const preset = userStore.getLocal().preferences.performancePreset;
+  applyPerformancePreset(preset, handles);
+}

--- a/src/engine/perf/treesController.ts
+++ b/src/engine/perf/treesController.ts
@@ -1,0 +1,16 @@
+import * as THREE from 'three';
+
+export function createTreesController(instanced: THREE.InstancedMesh) {
+  const max = instanced.count;
+  let current = max;
+  return {
+    setDensity(ratio: number) {
+      const clamped = Math.max(0, Math.min(1, ratio));
+      const target = Math.floor(max * clamped);
+      if (target === current) return;
+      instanced.count = target;
+      instanced.instanceMatrix.needsUpdate = true;
+      current = target;
+    }
+  };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -22,6 +22,8 @@ import { onTeleportLocal } from '@/world/worldBus';
 import { createGrowverseSign } from '@/scene/signage/GrowverseSign';
 import { systemStore } from '@/state/systemStore';
 import { registerTeleport } from '@/systems/teleport';
+import { applyPerformancePreset, EngineHandles } from '@/engine/perf/applyPerformancePreset';
+import { setEngineHandles } from '@/engine/perf/presets';
 import '@/styles/global.css';
 
 // Bootstrap React
@@ -65,7 +67,7 @@ async function initializeThreeWorld() {
     throw new Error('Required DOM elements not found');
   }
 
-  const { scene, camera, renderer, controls, amb, sun, adaptiveQuality } = createSceneSetup();
+  const { scene, camera, renderer, controls, amb, sun, adaptiveQuality, adaptiveQualityCtrl } = createSceneSetup();
   const keys = createInput();
 
   const { planeSize, stage, STAGE_W, STAGE_D, STAGE_H, insideStageXZ, groundYAt, boardBlock, stageBlock, boardZCenter, boardYCenter } = createGarden(scene);
@@ -278,7 +280,7 @@ async function initializeThreeWorld() {
     runtime.avatar.y = avatar.position.y;
     runtime.avatar.z = avatar.position.z;
     runtime.avatar.rotY = avatar.rotation.y;
-      worldfx.update();
+      worldfx.update(dt);
       updatePortalProximityFn();
       marquee.update(dt);
       teleprompter.update(dt);
@@ -290,5 +292,16 @@ async function initializeThreeWorld() {
       updateNameTag();
       nameTags.update(camera);
   }
+  const handles: EngineHandles = {
+    renderer,
+    sun,
+    worldfx,
+    trees: worldfx.trees,
+    marquee,
+    adaptiveQuality: adaptiveQualityCtrl,
+  };
+  setEngineHandles(handles);
+  applyPerformancePreset('high', handles);
+
   animate();
 }

--- a/src/state/userStore.tsx
+++ b/src/state/userStore.tsx
@@ -1,12 +1,7 @@
 import { createContext, useContext, useEffect, useReducer, useRef } from 'react';
 import { Role, InstructorSubRole, LearnerSubRole, AvatarUser as BasicUser } from '@/domain/roles';
 import { useBots, botControls } from '@/state/bots';
-
-export interface UserPreferences {
-  timeFormat: '24h' | '12h';
-  enableNotifications: boolean;
-  enableDarkMode: boolean;
-}
+import { AvatarUserPreferences, PerformancePreset } from '@/types/preferences';
 
 export interface AvatarUser {
   id: string;
@@ -14,7 +9,7 @@ export interface AvatarUser {
   role: Role;
   subRole?: InstructorSubRole | LearnerSubRole;
   isAdmin: boolean;
-  preferences: UserPreferences;
+  preferences: AvatarUserPreferences;
 }
 
 interface UserState {
@@ -23,7 +18,7 @@ interface UserState {
 
 interface UpdatePrefsAction {
   type: 'UPDATE_PREFS';
-  payload: Partial<UserPreferences>;
+  payload: Partial<AvatarUserPreferences>;
 }
 interface UpdateRoleAction {
   type: 'UPDATE_ROLE';
@@ -56,6 +51,7 @@ const initialUser: AvatarUser = {
   role: 'learner',
   isAdmin: true,
   preferences: {
+    performancePreset: 'high',
     timeFormat: '24h',
     enableNotifications: false,
     enableDarkMode: false,
@@ -119,12 +115,16 @@ export function selectOnlineUsers(): BasicUser[] {
   return [localBasic, ...botControls.getBots()];
 }
 
-export function updatePreferences(partial: Partial<UserPreferences>): void {
+export function updatePreferences(partial: Partial<AvatarUserPreferences>): void {
   userStore._dispatch?.({ type: 'UPDATE_PREFS', payload: partial });
 }
 
 export function updateLocalRole(role: Role, subRole?: InstructorSubRole | LearnerSubRole): void {
   userStore._dispatch?.({ type: 'UPDATE_ROLE', role, subRole });
+}
+
+export function setPerformancePreset(preset: PerformancePreset): void {
+  userStore._dispatch?.({ type: 'UPDATE_PREFS', payload: { performancePreset: preset } });
 }
 
 export const userStore = {

--- a/src/systems/marquee.ts
+++ b/src/systems/marquee.ts
@@ -26,6 +26,7 @@ export interface MarqueeSystem {
   group: THREE.Group;
   setText: (text: string) => void;
   update: (dt: number) => void;
+  setResolution: (w: number, h: number) => void;
 }
 
 export function createMarquee(scene: THREE.Scene, config: MarqueeConfig): MarqueeSystem {
@@ -158,5 +159,12 @@ export function createMarquee(scene: THREE.Scene, config: MarqueeConfig): Marque
     }
   }
 
-  return { group, setText, update };
+  function setResolution(w: number, h: number) {
+    if (w <= 0 || h <= 0) return;
+    canvas.width = w;
+    canvas.height = h;
+    redraw();
+  }
+
+  return { group, setText, update, setResolution };
 }

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -1,0 +1,8 @@
+export type PerformancePreset = 'low' | 'medium' | 'high';
+
+export interface AvatarUserPreferences {
+  performancePreset: PerformancePreset;
+  timeFormat: '24h' | '12h';
+  enableNotifications: boolean;
+  enableDarkMode: boolean;
+}

--- a/src/ui/settings/SettingsPanel.tsx
+++ b/src/ui/settings/SettingsPanel.tsx
@@ -4,6 +4,7 @@ import UserPreferencesView from './views/UserPreferencesView';
 import TimeFormatView from './views/TimeFormatView';
 import NotificationsView from './views/NotificationsView';
 import ThemeView from './views/ThemeView';
+import PerformanceView from './views/PerformanceView';
 import './settings.css';
 
 export default function SettingsPanel(): JSX.Element {
@@ -17,6 +18,9 @@ export default function SettingsPanel(): JSX.Element {
   }
   if (route === SettingsRoute.Theme) {
     return <ThemeView onBack={() => setRoute(SettingsRoute.UserPreferences)} />;
+  }
+  if (route === SettingsRoute.Performance) {
+    return <PerformanceView onBack={() => setRoute(SettingsRoute.UserPreferences)} />;
   }
 
   return <UserPreferencesView onNavigate={setRoute} />;

--- a/src/ui/settings/settingsRoutes.ts
+++ b/src/ui/settings/settingsRoutes.ts
@@ -3,4 +3,5 @@ export enum SettingsRoute {
   TimeFormat = 'time_format',
   Notifications = 'notifications',
   Theme = 'theme',
+  Performance = 'performance',
 }

--- a/src/ui/settings/views/PerformanceView.tsx
+++ b/src/ui/settings/views/PerformanceView.tsx
@@ -1,0 +1,57 @@
+import { setPerformancePreset, useUserStore } from '@/state/userStore';
+import { applyCurrentPreset } from '@/engine/perf/presets';
+import { PerformancePreset } from '@/types/preferences';
+
+interface Props {
+  onBack: () => void;
+}
+
+export default function PerformanceView({ onBack }: Props): JSX.Element {
+  const { state } = useUserStore();
+  const prefs = state.user.preferences;
+
+  function onChange(preset: PerformancePreset) {
+    setPerformancePreset(preset);
+    applyCurrentPreset();
+  }
+
+  return (
+    <div className="performance-view">
+      <div className="settings-detail-header">
+        <button className="back-btn" onClick={onBack}>
+          ← Back
+        </button>
+        <h3>User Preferences / Performance</h3>
+      </div>
+      <div className="settings-detail-content">
+        <label>
+          <input
+            type="radio"
+            name="perf"
+            checked={prefs.performancePreset === 'low'}
+            onChange={() => onChange('low')}
+          />
+          Low
+        </label>
+        <label>
+          <input
+            type="radio"
+            name="perf"
+            checked={prefs.performancePreset === 'medium'}
+            onChange={() => onChange('medium')}
+          />
+          Medium
+        </label>
+        <label>
+          <input
+            type="radio"
+            name="perf"
+            checked={prefs.performancePreset === 'high'}
+            onChange={() => onChange('high')}
+          />
+          High
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/settings/views/UserPreferencesView.tsx
+++ b/src/ui/settings/views/UserPreferencesView.tsx
@@ -39,6 +39,16 @@ export default function UserPreferencesView({ onNavigate }: Props): JSX.Element 
             <span className="chevron">›</span>
           </button>
         </li>
+        <li>
+          <button className="settings-home-item" onClick={() => onNavigate(SettingsRoute.Performance)}>
+            <span className="icon">⚙️</span>
+            <div className="text">
+              <div className="title">Performance / Quality</div>
+              <div className="desc">Adjust graphics quality.</div>
+            </div>
+            <span className="chevron">›</span>
+          </button>
+        </li>
       </ul>
     </div>
   );


### PR DESCRIPTION
## Summary
- add performance preset types and user store support
- implement engine performance controllers and preset application
- expose UI settings for Low/Medium/High quality presets

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689dab3f5c588324b198f1133c590294