### PR TITLE
feat: add landing shell and mock auth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^6.30.1",
         "three": "^0.158.0"
       },
       "devDependencies": {
@@ -745,6 +746,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1499,6 +1509,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/rollup": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.30.1",
     "three": "^0.158.0"
   },
   "devDependencies": {

--- a/src/app/AppRouter.tsx
+++ b/src/app/AppRouter.tsx
@@ -1,0 +1,32 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { AuthProvider } from '@/context/auth/AuthContext';
+import { Layout } from './Layout';
+import { App as GardenApp } from './App';
+import Landing from '@/pages/Landing/Landing';
+import About from '@/pages/About/About';
+import Login from '@/pages/Auth/Login';
+import Signup from '@/pages/Auth/Signup';
+import Profile from '@/pages/Profile/Profile';
+import SessionList from '@/pages/Session/SessionList';
+import SessionCreate from '@/pages/Session/SessionCreate';
+
+export function AppRouter(): JSX.Element {
+  return (
+    <AuthProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/garden" element={<GardenApp />} />
+          <Route element={<Layout />}>
+            <Route path="/" element={<Landing />} />
+            <Route path="/about" element={<About />} />
+            <Route path="/login" element={<Login />} />
+            <Route path="/signup" element={<Signup />} />
+            <Route path="/profile" element={<Profile />} />
+            <Route path="/session" element={<SessionList />} />
+            <Route path="/session/create" element={<SessionCreate />} />
+          </Route>
+        </Routes>
+      </BrowserRouter>
+    </AuthProvider>
+  );
+}

--- a/src/app/AppRouter.tsx
+++ b/src/app/AppRouter.tsx
@@ -9,6 +9,7 @@ import Signup from '@/pages/Auth/Signup';
 import Profile from '@/pages/Profile/Profile';
 import SessionList from '@/pages/Session/SessionList';
 import SessionCreate from '@/pages/Session/SessionCreate';
+import SessionLeave from '@/pages/Session/SessionLeave';
 
 export function AppRouter(): JSX.Element {
   return (
@@ -24,6 +25,7 @@ export function AppRouter(): JSX.Element {
             <Route path="/profile" element={<Profile />} />
             <Route path="/session" element={<SessionList />} />
             <Route path="/session/create" element={<SessionCreate />} />
+            <Route path="/session/leave" element={<SessionLeave />} />
           </Route>
         </Routes>
       </BrowserRouter>

--- a/src/app/Layout.tsx
+++ b/src/app/Layout.tsx
@@ -1,0 +1,14 @@
+import { Outlet } from 'react-router-dom';
+import { Navbar } from './Navbar';
+import './app.css';
+
+export function Layout(): JSX.Element {
+  return (
+    <div>
+      <Navbar />
+      <div className="container">
+        <Outlet />
+      </div>
+    </div>
+  );
+}

--- a/src/app/Navbar.tsx
+++ b/src/app/Navbar.tsx
@@ -1,0 +1,22 @@
+import { Link } from 'react-router-dom';
+import { useAuth } from '@/context/auth/AuthContext';
+
+export function Navbar(): JSX.Element {
+  const { user, logout } = useAuth();
+  return (
+    <nav className="navbar">
+      <Link to="/" className="nav-logo">Growverse</Link>
+      <div className="nav-right">
+        <Link to="/about">About</Link>
+        {user ? (
+          <button onClick={logout}>Logout</button>
+        ) : (
+          <>
+            <Link to="/login">Login</Link>
+            <Link to="/signup">Sign Up</Link>
+          </>
+        )}
+      </div>
+    </nav>
+  );
+}

--- a/src/app/Navbar.tsx
+++ b/src/app/Navbar.tsx
@@ -9,11 +9,11 @@ export function Navbar(): JSX.Element {
       <div className="nav-right">
         <Link to="/about">About</Link>
         {user ? (
-          <button onClick={logout}>Logout</button>
+          <button className="btn secondary" onClick={logout}>Logout</button>
         ) : (
           <>
-            <Link to="/login">Login</Link>
-            <Link to="/signup">Sign Up</Link>
+            <Link className="btn secondary" to="/login">Login</Link>
+            <Link className="btn" to="/signup">Sign Up</Link>
           </>
         )}
       </div>

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -1,18 +1,50 @@
 body {
   margin: 0;
-  font-family: sans-serif;
+  min-height: 100vh;
+  font-family: system-ui, sans-serif;
+  color: #eef1ff;
+  background: linear-gradient(135deg, #1c1d4f, #090b26);
+  position: relative;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(#fff 1px, transparent 1px) 0 0/40px 40px,
+    radial-gradient(#fff 1px, transparent 1px) 20px 20px/40px 40px;
+  opacity: 0.15;
+  pointer-events: none;
 }
 
 .navbar {
   display: flex;
   justify-content: space-between;
-  padding: 1rem;
-  border-bottom: 1px solid #ccc;
+  align-items: center;
+  padding: 1rem 2rem;
+  background: rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
 }
 
-.navbar a {
+.navbar a,
+.navbar button {
+  color: #eef1ff;
   text-decoration: none;
-  color: inherit;
+  border: none;
+  font: inherit;
+  cursor: pointer;
+}
+
+.navbar button:not(.btn) {
+  background: none;
+}
+
+.navbar a:hover,
+.navbar button:hover {
+  opacity: 0.8;
 }
 
 .nav-right > * {
@@ -20,5 +52,116 @@ body {
 }
 
 .container {
-  padding: 1rem;
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.card {
+  background: rgba(255, 255, 255, 0.08);
+  padding: 2rem;
+  border-radius: 16px;
+  backdrop-filter: blur(12px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+}
+
+.hero {
+  text-align: center;
+  margin-top: 10vh;
+}
+
+.hero h1 {
+  font-size: 4rem;
+  margin-bottom: 1rem;
+  text-shadow: 0 0 15px rgba(255, 255, 255, 0.6);
+}
+
+.cta {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.btn,
+button.btn {
+  display: inline-block;
+  background: #6366f1;
+  color: #fff;
+  border: none;
+  padding: 0.6rem 1.2rem;
+  border-radius: 8px;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.btn.secondary {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+button.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+input,
+select {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  background: rgba(255, 255, 255, 0.05);
+  color: #eef1ff;
+}
+
+input::placeholder {
+  color: #b6b9d6;
+}
+
+label {
+  display: grid;
+  gap: 0.25rem;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+th,
+td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+}
+
+tbody tr {
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+tbody tr:nth-child(even) {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+tbody tr:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.join-section {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.join-section input {
+  max-width: 300px;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+  max-width: 320px;
 }

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -1,0 +1,24 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+}
+
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  padding: 1rem;
+  border-bottom: 1px solid #ccc;
+}
+
+.navbar a {
+  text-decoration: none;
+  color: inherit;
+}
+
+.nav-right > * {
+  margin-left: 1rem;
+}
+
+.container {
+  padding: 1rem;
+}

--- a/src/context/auth/AuthContext.tsx
+++ b/src/context/auth/AuthContext.tsx
@@ -1,0 +1,34 @@
+import { createContext, useContext, useState, ReactNode } from 'react';
+import { AuthUser } from './types';
+
+interface AuthContextValue {
+  user: AuthUser | null;
+  login: () => void;
+  logout: () => void;
+}
+
+const defaultUser: AuthUser = {
+  username: 'macaris64',
+  role: 'instructor',
+  subRole: 'instructor',
+  isAdmin: true,
+};
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }): JSX.Element {
+  const [user, setUser] = useState<AuthUser | null>(defaultUser);
+  const login = () => setUser(defaultUser);
+  const logout = () => setUser(null);
+  return (
+    <AuthContext.Provider value={{ user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+}

--- a/src/context/auth/types.ts
+++ b/src/context/auth/types.ts
@@ -1,0 +1,6 @@
+export interface AuthUser {
+  username: string;
+  role: string;
+  subRole: string;
+  isAdmin: boolean;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -24,7 +24,7 @@ import { systemStore } from '@/state/systemStore';
 import { registerTeleport } from '@/systems/teleport';
 import { applyPerformancePreset, EngineHandles } from '@/engine/perf/applyPerformancePreset';
 import { setEngineHandles } from '@/engine/perf/presets';
-import '@/styles/global.css';
+import './styles/global.css';
 
 // Bootstrap React
 const appElement = document.getElementById('app');

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 // No React import needed for JSX in React 18+
 import { createRoot } from 'react-dom/client';
 import * as THREE from 'three';
-import { App } from '@/app/App';
+import { AppRouter } from '@/app/AppRouter';
 import { createSceneSetup } from '@/core/scene';
 import { createInput } from '@/core/input';
 import { createGarden } from '@/world/garden';
@@ -33,12 +33,14 @@ if (!appElement) {
 }
 
 const root = createRoot(appElement);
-root.render(<App />);
+root.render(<AppRouter />);
 
-// Initialize Three.js world after React has rendered
-setTimeout(() => {
-  void initializeThreeWorld();
-}, 0);
+// Initialize Three.js world only on /garden
+if (window.location.pathname === '/garden') {
+  setTimeout(() => {
+    void initializeThreeWorld();
+  }, 0);
+}
 
 async function initializeThreeWorld() {
   nameTags.mountNameTagsRoot();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -24,6 +24,7 @@ import { systemStore } from '@/state/systemStore';
 import { registerTeleport } from '@/systems/teleport';
 import { applyPerformancePreset, EngineHandles } from '@/engine/perf/applyPerformancePreset';
 import { setEngineHandles } from '@/engine/perf/presets';
+import { registerWorldCleanup } from '@/world/lifecycle';
 import './styles/global.css';
 
 // Bootstrap React
@@ -271,8 +272,9 @@ async function initializeThreeWorld() {
   }
 
   const clock = new THREE.Clock();
+  let frameId = 0;
   function animate() {
-    requestAnimationFrame(animate);
+    frameId = requestAnimationFrame(animate);
     const dtRaw = clock.getDelta();
     const fps = 1 / (dtRaw || 1);
     runtime.fps = runtime.fps * 0.9 + fps * 0.1;
@@ -316,4 +318,13 @@ async function initializeThreeWorld() {
   applyPerformancePreset('high', handles);
 
   animate();
+
+  registerWorldCleanup(() => {
+    cancelAnimationFrame(frameId);
+    renderer.dispose();
+    botManager.dispose();
+    sign.dispose();
+    nameTags.unmountNameTagsRoot();
+    renderer.domElement.remove();
+  });
 }

--- a/src/modules/session/sessions.mock.ts
+++ b/src/modules/session/sessions.mock.ts
@@ -1,0 +1,9 @@
+import { Session } from './types';
+
+export const sessions: Session[] = [
+  { id: 's1', name: 'Intro to Gardening', instructorName: 'Alice', startTime: '2024-01-01 10:00' },
+  { id: 's2', name: 'Advanced Botany', instructorName: 'Bob', startTime: '2024-01-02 11:00' },
+  { id: 's3', name: 'Soil Science', instructorName: 'Carol', startTime: '2024-01-03 12:00' },
+  { id: 's4', name: 'Hydroponics 101', instructorName: 'Dave', startTime: '2024-01-04 13:00' },
+  { id: 's5', name: 'Urban Farming', instructorName: 'Eve', startTime: '2024-01-05 14:00' },
+];

--- a/src/modules/session/types.ts
+++ b/src/modules/session/types.ts
@@ -1,0 +1,6 @@
+export interface Session {
+  id: string;
+  name: string;
+  instructorName: string;
+  startTime: string;
+}

--- a/src/modules/session/utils.ts
+++ b/src/modules/session/utils.ts
@@ -1,0 +1,3 @@
+export function openSessionWindow(sessionId: string): void {
+  window.open('/garden?sessionId=' + encodeURIComponent(sessionId), '_blank', 'noopener,noreferrer');
+}

--- a/src/pages/About/About.tsx
+++ b/src/pages/About/About.tsx
@@ -1,0 +1,8 @@
+export default function About(): JSX.Element {
+  return (
+    <div>
+      <h1>Growverse</h1>
+      <p>Growverse is a friendly virtual garden where learners and instructors explore together.</p>
+    </div>
+  );
+}

--- a/src/pages/About/About.tsx
+++ b/src/pages/About/About.tsx
@@ -1,6 +1,6 @@
 export default function About(): JSX.Element {
   return (
-    <div>
+    <div className="card">
       <h1>Growverse</h1>
       <p>Growverse is a friendly virtual garden where learners and instructors explore together.</p>
     </div>

--- a/src/pages/Auth/Login.tsx
+++ b/src/pages/Auth/Login.tsx
@@ -1,0 +1,25 @@
+import { FormEvent } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '@/context/auth/AuthContext';
+
+export default function Login(): JSX.Element {
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    login();
+    navigate('/');
+  }
+  return (
+    <form onSubmit={onSubmit}>
+      <h1>Login</h1>
+      <div>
+        <input placeholder="Username" required />
+      </div>
+      <div>
+        <input type="password" placeholder="Password" required />
+      </div>
+      <button type="submit">Login</button>
+    </form>
+  );
+}

--- a/src/pages/Auth/Login.tsx
+++ b/src/pages/Auth/Login.tsx
@@ -11,15 +11,13 @@ export default function Login(): JSX.Element {
     navigate('/');
   }
   return (
-    <form onSubmit={onSubmit}>
+    <form className="card" onSubmit={onSubmit} style={{ maxWidth: '320px', margin: '0 auto' }}>
       <h1>Login</h1>
-      <div>
+      <div className="form-grid">
         <input placeholder="Username" required />
-      </div>
-      <div>
         <input type="password" placeholder="Password" required />
+        <button className="btn" type="submit">Login</button>
       </div>
-      <button type="submit">Login</button>
     </form>
   );
 }

--- a/src/pages/Auth/Signup.tsx
+++ b/src/pages/Auth/Signup.tsx
@@ -1,0 +1,25 @@
+import { FormEvent } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '@/context/auth/AuthContext';
+
+export default function Signup(): JSX.Element {
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    login();
+    navigate('/');
+  }
+  return (
+    <form onSubmit={onSubmit}>
+      <h1>Sign Up</h1>
+      <div>
+        <input placeholder="Username" required />
+      </div>
+      <div>
+        <input type="password" placeholder="Password" required />
+      </div>
+      <button type="submit">Create Account</button>
+    </form>
+  );
+}

--- a/src/pages/Auth/Signup.tsx
+++ b/src/pages/Auth/Signup.tsx
@@ -11,15 +11,13 @@ export default function Signup(): JSX.Element {
     navigate('/');
   }
   return (
-    <form onSubmit={onSubmit}>
+    <form className="card" onSubmit={onSubmit} style={{ maxWidth: '320px', margin: '0 auto' }}>
       <h1>Sign Up</h1>
-      <div>
+      <div className="form-grid">
         <input placeholder="Username" required />
-      </div>
-      <div>
         <input type="password" placeholder="Password" required />
+        <button className="btn" type="submit">Create Account</button>
       </div>
-      <button type="submit">Create Account</button>
     </form>
   );
 }

--- a/src/pages/Landing/Landing.tsx
+++ b/src/pages/Landing/Landing.tsx
@@ -4,18 +4,20 @@ import { useAuth } from '@/context/auth/AuthContext';
 export default function Landing(): JSX.Element {
   const { user } = useAuth();
   return (
-    <div>
+    <div className="hero">
       <h1>Growverse</h1>
       {user && (
-        <div style={{ display: 'flex', gap: '1rem', marginBottom: '1rem' }}>
-          <Link to="/profile">Profile</Link>
-          <Link to="/session">Create / Join Session</Link>
+        <div className="cta">
+          <Link className="btn" to="/profile">Profile</Link>
+          <Link className="btn" to="/session">Create / Join Session</Link>
         </div>
       )}
-      <div>
+      <div className="card" style={{ marginTop: '3rem' }}>
         <h2>Join with URL</h2>
-        <input placeholder="Session URL" />
-        <button>Join</button>
+        <div className="join-section">
+          <input placeholder="Session URL" />
+          <button className="btn">Join</button>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/Landing/Landing.tsx
+++ b/src/pages/Landing/Landing.tsx
@@ -1,0 +1,22 @@
+import { Link } from 'react-router-dom';
+import { useAuth } from '@/context/auth/AuthContext';
+
+export default function Landing(): JSX.Element {
+  const { user } = useAuth();
+  return (
+    <div>
+      <h1>Growverse</h1>
+      {user && (
+        <div style={{ display: 'flex', gap: '1rem', marginBottom: '1rem' }}>
+          <Link to="/profile">Profile</Link>
+          <Link to="/session">Create / Join Session</Link>
+        </div>
+      )}
+      <div>
+        <h2>Join with URL</h2>
+        <input placeholder="Session URL" />
+        <button>Join</button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -1,0 +1,17 @@
+import { useAuth } from '@/context/auth/AuthContext';
+
+export default function Profile(): JSX.Element {
+  const { user } = useAuth();
+  if (!user) return <p>Not logged in.</p>;
+  return (
+    <div>
+      <h1>Profile</h1>
+      <div style={{ display: 'grid', gap: '0.5rem', maxWidth: '300px' }}>
+        <label>
+          Username
+          <input value={user.username} readOnly />
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -4,9 +4,9 @@ export default function Profile(): JSX.Element {
   const { user } = useAuth();
   if (!user) return <p>Not logged in.</p>;
   return (
-    <div>
+    <div className="card" style={{ maxWidth: '320px', margin: '0 auto' }}>
       <h1>Profile</h1>
-      <div style={{ display: 'grid', gap: '0.5rem', maxWidth: '300px' }}>
+      <div className="form-grid">
         <label>
           Username
           <input value={user.username} readOnly />

--- a/src/pages/Session/SessionCreate.tsx
+++ b/src/pages/Session/SessionCreate.tsx
@@ -14,15 +14,13 @@ export default function SessionCreate(): JSX.Element {
   const disabled = !name || !role;
 
   return (
-    <form onSubmit={onSubmit}>
+    <form className="card" onSubmit={onSubmit} style={{ maxWidth: '400px', margin: '0 auto' }}>
       <h1>Create Session</h1>
-      <div>
+      <div className="form-grid">
         <label>
           Session Name
           <input value={name} onChange={(e) => setName(e.target.value)} required />
         </label>
-      </div>
-      <div>
         <label>
           Role
           <select value={role} onChange={(e) => setRole(e.target.value)} required>
@@ -31,8 +29,8 @@ export default function SessionCreate(): JSX.Element {
             <option value="instructor">Instructor</option>
           </select>
         </label>
+        <button className="btn" type="submit" disabled={disabled}>Create</button>
       </div>
-      <button type="submit" disabled={disabled}>Create</button>
     </form>
   );
 }

--- a/src/pages/Session/SessionCreate.tsx
+++ b/src/pages/Session/SessionCreate.tsx
@@ -1,0 +1,38 @@
+import { FormEvent, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export default function SessionCreate(): JSX.Element {
+  const [name, setName] = useState('');
+  const [role, setRole] = useState('');
+  const navigate = useNavigate();
+
+  function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    navigate('/session');
+  }
+
+  const disabled = !name || !role;
+
+  return (
+    <form onSubmit={onSubmit}>
+      <h1>Create Session</h1>
+      <div>
+        <label>
+          Session Name
+          <input value={name} onChange={(e) => setName(e.target.value)} required />
+        </label>
+      </div>
+      <div>
+        <label>
+          Role
+          <select value={role} onChange={(e) => setRole(e.target.value)} required>
+            <option value="">Select role</option>
+            <option value="learner">Learner</option>
+            <option value="instructor">Instructor</option>
+          </select>
+        </label>
+      </div>
+      <button type="submit" disabled={disabled}>Create</button>
+    </form>
+  );
+}

--- a/src/pages/Session/SessionLeave.tsx
+++ b/src/pages/Session/SessionLeave.tsx
@@ -1,0 +1,24 @@
+import { useNavigate } from 'react-router-dom';
+import { useSessionStore } from '@/state/sessionStore';
+
+export default function SessionLeave(): JSX.Element {
+  const navigate = useNavigate();
+  const { activeSession } = useSessionStore();
+  return (
+    <div className="container">
+      <h1>You have left the session.</h1>
+      {activeSession && (
+        <div className="card" style={{ margin: '2rem 0' }}>
+          <h2>{activeSession.name}</h2>
+          <p>
+            {activeSession.currentLearners} / {activeSession.maxLearners} learners
+          </p>
+          <p>
+            Time: {activeSession.currentTime} ({activeSession.currentTimezone})
+          </p>
+        </div>
+      )}
+      <button className="btn" onClick={() => navigate('/')}>Return to Landing</button>
+    </div>
+  );
+}

--- a/src/pages/Session/SessionLeave.tsx
+++ b/src/pages/Session/SessionLeave.tsx
@@ -1,21 +1,29 @@
-import { useNavigate } from 'react-router-dom';
-import { useSessionStore } from '@/state/sessionStore';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 export default function SessionLeave(): JSX.Element {
   const navigate = useNavigate();
-  const { activeSession } = useSessionStore();
+  const [params] = useSearchParams();
+  const name = params.get('name');
+  const currentLearners = params.get('currentLearners');
+  const maxLearners = params.get('maxLearners');
+  const currentTime = params.get('currentTime');
+  const currentTimezone = params.get('currentTimezone');
   return (
     <div className="container">
       <h1>You have left the session.</h1>
-      {activeSession && (
+      {name && (
         <div className="card" style={{ margin: '2rem 0' }}>
-          <h2>{activeSession.name}</h2>
-          <p>
-            {activeSession.currentLearners} / {activeSession.maxLearners} learners
-          </p>
-          <p>
-            Time: {activeSession.currentTime} ({activeSession.currentTimezone})
-          </p>
+          <h2>{name}</h2>
+          {currentLearners && maxLearners && (
+            <p>
+              {currentLearners} / {maxLearners} learners
+            </p>
+          )}
+          {currentTime && currentTimezone && (
+            <p>
+              Time: {currentTime} ({currentTimezone})
+            </p>
+          )}
         </div>
       )}
       <button className="btn" onClick={() => navigate('/')}>Return to Landing</button>

--- a/src/pages/Session/SessionList.tsx
+++ b/src/pages/Session/SessionList.tsx
@@ -1,0 +1,30 @@
+import { Link } from 'react-router-dom';
+import { sessions } from '@/modules/session/sessions.mock';
+import { openSessionWindow } from '@/modules/session/utils';
+
+export default function SessionList(): JSX.Element {
+  return (
+    <div>
+      <h1>Sessions</h1>
+      <Link to="/session/create">Create Session</Link>
+      <table border={1} cellPadding={4} cellSpacing={0} style={{ marginTop: '1rem', width: '100%', maxWidth: '600px' }}>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Instructor</th>
+            <th>Start Time</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sessions.map((s) => (
+            <tr key={s.id} style={{ cursor: 'pointer' }} onClick={() => openSessionWindow(s.id)}>
+              <td>{s.name}</td>
+              <td>{s.instructorName}</td>
+              <td>{s.startTime}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/pages/Session/SessionList.tsx
+++ b/src/pages/Session/SessionList.tsx
@@ -4,10 +4,10 @@ import { openSessionWindow } from '@/modules/session/utils';
 
 export default function SessionList(): JSX.Element {
   return (
-    <div>
+    <div className="card">
       <h1>Sessions</h1>
-      <Link to="/session/create">Create Session</Link>
-      <table border={1} cellPadding={4} cellSpacing={0} style={{ marginTop: '1rem', width: '100%', maxWidth: '600px' }}>
+      <Link className="btn" to="/session/create">Create Session</Link>
+      <table>
         <thead>
           <tr>
             <th>Name</th>
@@ -17,7 +17,7 @@ export default function SessionList(): JSX.Element {
         </thead>
         <tbody>
           {sessions.map((s) => (
-            <tr key={s.id} style={{ cursor: 'pointer' }} onClick={() => openSessionWindow(s.id)}>
+            <tr key={s.id} onClick={() => openSessionWindow(s.id)}>
               <td>{s.name}</td>
               <td>{s.instructorName}</td>
               <td>{s.startTime}</td>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -119,6 +119,12 @@ canvas {
   background: rgba(130,180,255,.18);
 }
 
+.btn.danger {
+  border-color: rgba(255,120,120,.6);
+  background: rgba(255,120,120,.18);
+  color: #ffecec;
+}
+
 .finished-badge {
   background: #3b82f6;
   color: #fff;

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -26,4 +26,6 @@ declare module 'three' {
   }
 }
 
+declare module '*.css';
+
 export {};

--- a/src/ui/dock.css
+++ b/src/ui/dock.css
@@ -160,3 +160,21 @@
   font-size: 12px;
   opacity: .7;
 }
+
+/* Info tab */
+.info-tab .info-section {
+  margin-bottom: 12px;
+}
+
+.info-tab .info-section h3 {
+  margin: 0 0 4px;
+  font-size: 12px;
+  text-transform: uppercase;
+  opacity: .7;
+}
+
+.info-tab .info-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}

--- a/src/ui/tabs/InfoTab.tsx
+++ b/src/ui/tabs/InfoTab.tsx
@@ -63,8 +63,18 @@ export function InfoTab(): JSX.Element {
   }
 
   function handleLeaveSession() {
+    const params = new URLSearchParams();
+    if (activeSession) {
+      params.set('name', activeSession.name);
+      params.set('currentLearners', String(activeSession.currentLearners));
+      params.set('maxLearners', String(activeSession.maxLearners));
+      params.set('currentTime', activeSession.currentTime);
+      params.set('currentTimezone', activeSession.currentTimezone);
+    }
     destroyWorld();
-    window.location.href = '/session/leave';
+    const query = params.toString();
+    const url = query ? `/session/leave?${query}` : '/session/leave';
+    window.location.href = url;
   }
 
   return (

--- a/src/ui/tabs/InfoTab.tsx
+++ b/src/ui/tabs/InfoTab.tsx
@@ -5,6 +5,7 @@ import { useLocalUser } from '@/state/userStore';
 import { RoleLabels } from '@/domain/roles';
 import { useSessionStore } from '@/state/sessionStore';
 import { formatCountdown, clampToZero } from '@/utils/time';
+import { destroyWorld } from '@/world/lifecycle';
 
 interface AvatarState {
   x: number;
@@ -57,28 +58,41 @@ export function InfoTab(): JSX.Element {
     : 0;
   const finished = remainingMs === 0;
 
+  function handleCopyUrl() {
+    void navigator.clipboard.writeText(window.location.href);
+  }
+
+  function handleLeaveSession() {
+    destroyWorld();
+    window.location.href = '/session/leave';
+  }
+
   return (
     <div className="info-tab">
       {local && (
-        <div>
-          User: {local.name}{' '}
-          <span
-            style={{
-              background: RoleLabels[local.role].color,
-              color: '#fff',
-              padding: '2px 6px',
-              borderRadius: '4px',
-            }}
-          >
-            {RoleLabels[local.role].label}
-            {local.subRole ? ` > ${local.subRole}` : ''}
-          </span>
+        <div className="info-section">
+          <h3>User</h3>
+          <div>
+            {local.name}{' '}
+            <span
+              style={{
+                background: RoleLabels[local.role].color,
+                color: '#fff',
+                padding: '2px 6px',
+                borderRadius: '4px',
+              }}
+            >
+              {RoleLabels[local.role].label}
+              {local.subRole ? ` > ${local.subRole}` : ''}
+            </span>
+          </div>
         </div>
       )}
       {activeSession && (
-        <>
+        <div className="info-section">
+          <h3>Session</h3>
           <div>
-            Session: {activeSession.name}
+            {activeSession.name}
             {activeSession.instanceTitle ? ` – ${activeSession.instanceTitle}` : ''}
           </div>
           <div>
@@ -91,13 +105,20 @@ export function InfoTab(): JSX.Element {
             Countdown: {formatCountdown(remainingMs)}{' '}
             {finished && <span className="finished-badge pulse">Session finished</span>}
           </div>
-        </>
+        </div>
       )}
-      <div>
-        Position: {utils.fmt(avatar.x)} / {utils.fmt(avatar.y)} / {utils.fmt(avatar.z)}
+      <div className="info-section">
+        <h3>Metrics</h3>
+        <div>Position: {utils.fmt(avatar.x)} / {utils.fmt(avatar.y)} / {utils.fmt(avatar.z)}</div>
+        <div>Rot Y: {heading.toFixed(1)}</div>
+        <div>FPS: {fps.toFixed(1)}</div>
       </div>
-      <div>Rot Y: {heading.toFixed(1)}</div>
-      <div>FPS: {fps.toFixed(1)}</div>
+      {activeSession && (
+        <div className="info-actions">
+          <button className="btn" onClick={handleCopyUrl}>Copy session URL</button>
+          <button className="btn danger" onClick={handleLeaveSession}>Leave session</button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/world/lifecycle.ts
+++ b/src/world/lifecycle.ts
@@ -1,0 +1,12 @@
+let cleanup: (() => void) | null = null;
+
+export function registerWorldCleanup(fn: () => void): void {
+  cleanup = fn;
+}
+
+export function destroyWorld(): void {
+  if (cleanup) {
+    cleanup();
+    cleanup = null;
+  }
+}

--- a/src/world/nameTags.ts
+++ b/src/world/nameTags.ts
@@ -22,6 +22,14 @@ export function mountNameTagsRoot(): void {
   document.body.appendChild(root);
 }
 
+export function unmountNameTagsRoot(): void {
+  if (root && root.parentNode) {
+    root.parentNode.removeChild(root);
+  }
+  root = null;
+  tags.clear();
+}
+
 export function register(obj: THREE.Object3D, label: string): string {
   if (!root) mountNameTagsRoot();
   const el = document.createElement('div');


### PR DESCRIPTION
## Summary
- add React Router shell with landing and session pages
- include mock AuthContext and navbar
- stub session utilities and creation flow

## Testing
- `npm run typecheck`
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_689dc2e1b2dc8324aeb78f502f62caa8